### PR TITLE
カテゴリ検索の追加

### DIFF
--- a/webapp/src/pages/Top.js
+++ b/webapp/src/pages/Top.js
@@ -2,15 +2,39 @@
 import React, {useState} from 'react';
 import Layout from '../components/layout/Layout';
 
-import { makeStyles, Grid, Container, IconButton, Paper, InputBase, Card, CardActions, CardContent, Button, Typography} from "@material-ui/core";
+import {
+  makeStyles,
+  Grid,
+  Container,
+  IconButton,
+  Paper,
+  InputBase,
+  Card,
+  CardActions,
+  CardContent,
+  Button,
+  Typography,
+  FormControl,
+  Select,
+  MenuItem
+} from "@material-ui/core";
 import SearchIcon from '@material-ui/icons/Search';
 
 import { queryDiscovery }from '../utils/index';
+import { discoveryCategories } from '../utils/discoveryCategories';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
+  form: {
     marginTop: '20px',
     marginBottom: '20px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  select: {
+    marginRight: '20px',
+    backgroundColor: '#fff',
+  },
+  inputContainer: {
     padding: '2px 4px',
     display: 'flex',
     alignItems: 'center',
@@ -42,12 +66,13 @@ const useStyles = makeStyles((theme) => ({
 const Top = () => {
   const [sendText, setSendText] = useState('');
   const [recvText, setRecvText] = useState('');
+  const [categoryId, setCategoryId] = useState(0);
 
   const classes = useStyles();
 
   const onPressQuery = async (event) => {
     event.preventDefault();
-    const res = await queryDiscovery(sendText);
+    const res = await queryDiscovery(sendText, categoryId);
     setRecvText(res.data.responseText);
     console.log(res);
     // setSendText('');
@@ -81,19 +106,26 @@ const Top = () => {
 
   return (
     <Layout>
-      <form onSubmit={(e)=>{onPressQuery(e)}}>
-        <Paper className={classes.root}>
+      <form onSubmit={(e)=>{onPressQuery(e)}} className={classes.form}>
+        <FormControl variant="outlined" className={classes.select}>
+          <Select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+            <MenuItem value={0}>カテゴリを選択</MenuItem>
+            {discoveryCategories.map(([id, label]) => (
+              <MenuItem value={id}>{label}</MenuItem>
+              ))}
+          </Select>
+        </FormControl>
+        <Paper className={classes.inputContainer}>
           <InputBase
             className={classes.input}
             placeholder="Watson Discovery で検索"
             inputProps={{ 'aria-label': 'search watson discovery' }}
             onChange={(e)=>{setSendText(e.target.value)}}
           />
-          <IconButton 
-            type="button"
+          <IconButton
+            type="submit"
             className={classes.iconButton}
             aria-label="search"
-            onClick={(e) => onPressQuery(e)}
           >
             <SearchIcon />
           </IconButton>

--- a/webapp/src/utils/discoveryCategories.js
+++ b/webapp/src/utils/discoveryCategories.js
@@ -1,0 +1,4 @@
+export const discoveryCategories = [
+  [1, 'label1'],
+  [2, 'label2'],
+]

--- a/webapp/src/utils/index.js
+++ b/webapp/src/utils/index.js
@@ -12,8 +12,9 @@ const api = axios.create({
   responseType: 'json',
 })
 
-export const queryDiscovery = async (searchText) => {
+export const queryDiscovery = async (searchText, category) => {
   return await api.post('/discovery/search', {
-    searchText: searchText
+    searchText: searchText,
+    category,
   })
 }


### PR DESCRIPTION
## やったこと

- 検索ボックスの左にカテゴリのプルダウンを追加
- 検索した際のAPIのリクエストに、`category`を追加

```
{
  "category": 1,
  "searchText": "test"
}
```

## 備考

カテゴリのマスターはWatson Discoveryのセッティングが完了次第修正します。

## スクリーンショット

<img width="664" alt="スクリーンショット 2021-12-09 11 18 31" src="https://user-images.githubusercontent.com/12682382/145322626-2a1588c6-e2d9-4547-92c8-c9c3cee86c2b.png">
